### PR TITLE
Add service that exposes version

### DIFF
--- a/feature/feature.xml
+++ b/feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jazzcommunity.GitConnectorService.feature"
       label="REST Service"
-      version="1.3.0.qualifier"
+      version="1.4.0.qualifier"
       provider-name="PROVIDER">
 
    <description url="http://www.example.com/description">

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.jazzcommunity.GitConnectorService</groupId>
 		<artifactId>org.jazzcommunity.GitConnectorService.parent</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.4.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 

--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.jazzcommunity.GitConnectorService
 Bundle-SymbolicName: org.jazzcommunity.GitConnectorService;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.4.0.qualifier
 Bundle-Vendor: VENDOR
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jazzcommunity.GitConnectorService</groupId>
         <artifactId>org.jazzcommunity.GitConnectorService.parent</artifactId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/plugin/src/main/java/org/jazzcommunity/GitConnectorService/GitConnectorService.java
+++ b/plugin/src/main/java/org/jazzcommunity/GitConnectorService/GitConnectorService.java
@@ -6,11 +6,15 @@ import com.siemens.bt.jazz.services.base.rest.RestAction;
 import com.siemens.bt.jazz.services.base.rest.RestActionBuilder;
 import com.siemens.bt.jazz.services.base.rest.RestRequest;
 import com.siemens.bt.jazz.services.base.router.factory.RestFactory;
+import org.eclipse.core.runtime.Platform;
+import org.jazzcommunity.GitConnectorService.builder.VersionService;
 import org.jazzcommunity.GitConnectorService.builder.gitlab.IssueLinkService;
 import org.jazzcommunity.GitConnectorService.builder.gitlab.IssuePreviewService;
 import org.jazzcommunity.GitConnectorService.builder.gitlab.RequestLinkService;
 import org.jazzcommunity.GitConnectorService.builder.gitlab.RequestPreviewService;
 import org.jazzcommunity.GitConnectorService.router.CustomRouter;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.Version;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -41,12 +45,19 @@ public class GitConnectorService extends TeamRawService implements IGitConnector
                 "gitlab/[a-zA-Z.]+/project/[0-9]+/issue/[0-9]+/preview.*",
                 new RestFactory(IssuePreviewService.class));
 
-        router.addService(HttpMethod.GET,
+        router.addService(
+                HttpMethod.GET,
                 "gitlab/[a-zA-Z.]+/project/[0-9]+/merge-request/[0-9]+/link.*",
                 new RestFactory(RequestLinkService.class));
-        router.addService(HttpMethod.GET,
+        router.addService(
+                HttpMethod.GET,
                 "gitlab/[a-zA-Z.]+/project/[0-9]+/merge-request/[0-9]+/preview.*",
                 new RestFactory(RequestPreviewService.class));
+
+        router.addService(
+                HttpMethod.GET,
+                "info/version",
+                new RestFactory(VersionService.class));
 
         /**
          * This code is purposely commented out and not deleted!

--- a/plugin/src/main/java/org/jazzcommunity/GitConnectorService/builder/VersionService.java
+++ b/plugin/src/main/java/org/jazzcommunity/GitConnectorService/builder/VersionService.java
@@ -1,0 +1,44 @@
+package org.jazzcommunity.GitConnectorService.builder;
+
+import com.google.gson.*;
+import com.ibm.team.repository.service.TeamRawService;
+import com.siemens.bt.jazz.services.base.rest.AbstractRestService;
+import com.siemens.bt.jazz.services.base.rest.RestRequest;
+import org.apache.commons.logging.Log;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.Version;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class VersionService extends AbstractRestService {
+    private static Gson gson = new GsonBuilder()
+            .setPrettyPrinting()
+            .create();
+
+    public VersionService(Log log, HttpServletRequest request, HttpServletResponse response, RestRequest restRequest, TeamRawService parentService) {
+        super(log, request, response, restRequest, parentService);
+    }
+
+    @Override
+    public void execute() throws Exception {
+        Version version = FrameworkUtil.getBundle(getClass()).getVersion();
+        response.getWriter().write(gson.toJson(new VersionAdapter(version)));
+    }
+
+    private static final class VersionAdapter {
+        private final int major;
+        private final int minor;
+        private final int micro;
+        private final String qualifier;
+        private final String version;
+
+        public VersionAdapter(Version version) {
+            major = version.getMajor();
+            minor = version.getMinor();
+            micro = version.getMicro();
+            qualifier = version.getQualifier();
+            this.version = version.toString();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.jazzcommunity.GitConnectorService</groupId>
     <artifactId>org.jazzcommunity.GitConnectorService.parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/test/META-INF/MANIFEST.MF
+++ b/test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.jazzcommunity.GitConnectorService
 Bundle-SymbolicName: org.jazzcommunity.GitConnectorService.test;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.4.0.qualifier
 Bundle-Vendor: VENDOR
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: target/dependency/junit-4.12.jar,
@@ -10,7 +10,7 @@ Bundle-ClassPath: target/dependency/junit-4.12.jar,
  target/dependency/gson-2.8.2.jar,
  target/dependency/com.siemens.bt.jazz.services.base-2.0.1-SNAPSHOT.jar,
  target/dependency/com.siemens.bt.jazz.services.PersonalTokenService-1.0.2-SNAPSHOT.jar,
- target/dependency/org.jazzcommunity.GitConnectorService-1.3.0-SNAPSHOT.jar,
+ target/dependency/org.jazzcommunity.GitConnectorService-1.4.0-SNAPSHOT.jar,
  target/dependency/asm-5.0.3.jar,
  target/dependency/asm-analysis-5.0.3.jar,
  target/dependency/asm-tree-5.0.3.jar,

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
         <groupId>org.jazzcommunity.GitConnectorService</groupId>
         <artifactId>org.jazzcommunity.GitConnectorService.parent</artifactId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.jazzcommunity.GitConnectorService</groupId>
             <artifactId>org.jazzcommunity.GitConnectorService</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>1.4.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/update-site/pom.xml
+++ b/update-site/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jazzcommunity.GitConnectorService</groupId>
         <artifactId>org.jazzcommunity.GitConnectorService.parent</artifactId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
Currently, the active version is displayed on the `ccm/service` site. Added a service which also exposes the current deployment version through an http endpoint. This can be useful for displaying the version somewhere else, such as the git connector ui.